### PR TITLE
Adding elm-init to tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Inspired by the [awesome](https://github.com/bayandin/awesome-awesomeness) list 
     - [Articles](#articles)
     - [Libraries](#libraries)
     - [Tools](#tools)
-    - [Package managers](#package-managers)    
+    - [Package managers](#package-managers)
     - [Misc](#misc)
     - [Support](#support)
     - [Who to follow](#who-to-follow)
@@ -79,6 +79,7 @@ Inspired by the [awesome](https://github.com/bayandin/awesome-awesomeness) list 
 * [elm-reactor](https://github.com/elm-lang/elm-reactor) - Interactive development tool that makes it easy to develop and debug Elm programs.
 * [elm-repl](https://github.com/elm-lang/elm-repl) - A REPL for Elm.
 * [elm-package](https://github.com/elm-lang/elm-package) - CLI to share Elm libraries.
+* [elm-init](https://github.com/JustusAdam/elm-init) - Interactive setup for new Elm projects.
 
 **[:arrow_up: back to top](#table-of-contents)**
 


### PR DESCRIPTION
I propose to add the elm project initialiser command line tool that I wrote to the list.

I know it is not a hugely important tool like the compiler or the reactor, but never the less I feel it's a nice tool to have for your elm projects, or at least one that I wanted to have (which is why I wrote it).

Sorry for the one line that my editor automatically changed, I didn't bother removing the change.
