### PR TITLE
Add haskell-to-elm example list

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Inspired by the [awesome](#more-awesome) list thing. Feel free to <a href="https
 * [Learning FP the hard way](https://gist.github.com/ohanhi/0d3d83cf3f0d7bbea9db) - Experiences on the Elm language.
 * [Introduction to Rx](https://gist.github.com/staltz/868e7e9bc2a7b8c1f754) - The introduction to Reactive Programming you've been missing.
 * [Elm for Web Developers](https://github.com/eeue56/elm-for-web-developers) - A collection of notes for web developers looking into moving to Elm.
+* [Haskell to Elm](https://github.com/eeue56/haskell-to-elm) - Collection of examples on places where Elm is different to Haskell, targetted at Elm beginners coming from Haskell backgrounds.
 
 **[:arrow_up: back to top](#table-of-contents)**
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ Inspired by the [awesome](#more-awesome) list thing. Feel free to <a href="https
 * [Learning FP the hard way](https://gist.github.com/ohanhi/0d3d83cf3f0d7bbea9db) - Experiences on the Elm language.
 * [Introduction to Rx](https://gist.github.com/staltz/868e7e9bc2a7b8c1f754) - The introduction to Reactive Programming you've been missing.
 * [Elm for Web Developers](https://github.com/eeue56/elm-for-web-developers) - A collection of notes for web developers looking into moving to Elm.
-* [Haskell to Elm](https://github.com/eeue56/haskell-to-elm) - Collection of examples on places where Elm is different to Haskell, targetted at Elm beginners coming from Haskell backgrounds.
 
 **[:arrow_up: back to top](#table-of-contents)**
 
@@ -114,7 +113,8 @@ Inspired by the [awesome](#more-awesome) list thing. Feel free to <a href="https
 *Everything that you need to see.*
 
 * [Try Elm](http://elm-lang.org/try) - Write and compile elm code online!
-* [Debug Elm](http://debug.elm-lang.org/try) - Debug elm code online.
+* [Debug Elm](http://debug.elm-lang.org/try) - Debug elm code online
+* [Haskell to Elm](https://github.com/eeue56/haskell-to-elm) - Collection of examples on places where Elm is different to Haskell, targetted at Elm beginners coming from Haskell backgrounds..
 
 
 **[:arrow_up: back to top](#table-of-contents)**


### PR DESCRIPTION
Haskell-to-elm is a growing list of examples of differences between Haskell and Elm, grown from a class of Haskell-background students I was teaching Elm to.
