### PR TITLE
Remove elm-by-example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Inspired by the [awesome](#more-awesome) list thing. Feel free to <a href="https
 *Learn what this awesome thing is.*
 
 * [Official tutorial](http://elm-lang.org/docs) — General information and in-depth guide with examples.
-* [Elm by example](http://elm-by-example.org/toc.html) - Elm tutorial via set of practice chapters.
 * [Elm’s Time Traveling Debugger](http://debug.elm-lang.org/) - Debugger that lets you travel backwards and forwards in time.
 * [Architecture Tutorial](https://github.com/evancz/elm-architecture-tutorial) - How to create modular Elm code that scales nicely with your app.
 * [Start app](https://github.com/evancz/start-app) - Make an app, start it up.


### PR DESCRIPTION
It is no longer maintained [since elm 0.15](https://github.com/grzegorzbalcerek/elm-by-example/issues) and only leads to confusion.
