### PR TITLE
Add elm-todo-rest-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Inspired by the [awesome](#more-awesome) list thing. Feel free to <a href="https
 * [Vessel](https://github.com/slawrence/vessel) - A "tunnel" game written in Elm!
 * [Sliding Puzzle](https://github.com/moroshko/sliding-puzzle) - Configurable sliding puzzle game written in Elm.
 * [TodoMVC](https://github.com/evancz/elm-todomvc) - Proper implementation of the TodoMVC app.
+* [TodoMVC with JSON API](https://github.com/andrewsuzuki/elm-todo-rest-api) - Bare-bones, modular, heavilty-documented todo app with JSON API persistence.
 * [TodoMVC/Firebase](https://github.com/ThomasWeiser/todomvc-elmfire) - Fork of TodoMVC demonstrating start-app, [The Elm Architecture](https://github.com/evancz/elm-architecture-tutorial) and Firebase as backend.
 * [\<elm-ement\>](https://github.com/ohanhi/elm-ement) – Minimal example of a custom element.
 * [Elm Playground](http://elm-playground.maciejsmolinski.com/) - Tiny Elm projects implemented for the sake of learning by example.


### PR DESCRIPTION
The official elm-todomvc uses localStorage to persist state.

Then there's todomvc-elmfire which uses Firebase (and elm 0.16 signals).

Both of them are in single elm source files as well.

Since vanilla rest APIs are by far the most common type of web app persistence (and real-world elm apps should be much more modular), I decided to make another elm todo app with a fake json rest api.
The code is heavily-documented so it suits beginner users better than the other two as well.

Would love to hear any feedback!

[elm-todo-rest-api](https://github.com/andrewsuzuki/elm-todo-rest-api)
