### PR TITLE
Add create-elm-app to tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Inspired by the [awesome](#more-awesome) list thing. Feel free to <a href="https
 * [elm-webpack-loader](https://github.com/rtfeldman/elm-webpack-loader) - Webpack loader for the Elm programming language.
 * [servelm](https://github.com/eeue56/servelm) - A project enabling server-side use of Elm.
 * [elm-oracle](https://github.com/ElmCast/elm-oracle) - Query for information about values in elm source files. Used by most editor plugins.
+* [create-elm-app](https://github.com/halfzebra/create-elm-app) - Create Elm apps with no build configuration.
 
 **[:arrow_up: back to top](#table-of-contents)**
 


### PR DESCRIPTION
Hello,

This PR adds [create-elm-app](https://github.com/halfzebra/create-elm-app) under the tools section. See [this medium post](https://medium.com/@eduardkyvenko/how-to-create-elm-app-cf052629a11a#.lzy7tq3rl) for more information about the tool.
