### PR TITLE
Add Dependabot to tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Inspired by the [awesome](#more-awesome) list thing. Feel free to <a href="https
 * [elm-analyse](https://github.com/stil4m/elm-analyse) - Linter for the Elm programming language.
 * [run-elm](https://github.com/jfairbank/run-elm) — Run Elm code from the command line
 * [type-o-rama](https://github.com/stereobooster/type-o-rama) - JS type systems interportability.
+* [Dependabot](https://dependabot.com) - Automatic update PRs for your elm-package.json.
 
 **[:arrow_up: back to top](#table-of-contents)**
 


### PR DESCRIPTION
I recently added Elm support to [Dependabot](https://dependabot.com/), and would love to have it featured here. I've linked to the main site for the tool, rather than the source code (which is [here](https://github.com/dependabot/dependabot-core)) because I think it's clearer and is how you'd install it, but let me know if you'd prefer a link to the source.