### PR TITLE
Problem: Potentially confusing reference to QML

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Inspired by the [awesome](#more-awesome) list thing. Feel free to <a href="https
     - [Articles](#articles)
     - [Videos](#videos)
     - [Podcasts](#podcasts)
-    - [Languages](#languages)
     - [Libraries](#libraries)
     - [Tools](#tools)
     - [Editor plugins](#editor-plugins)
@@ -165,11 +164,6 @@ Inspired by the [awesome](#more-awesome) list thing. Feel free to <a href="https
 * [InfoQ Podcast 2017-04-27](https://www.infoq.com/podcasts/richard-feldman) - Richard Feldman discusses how Elm compares to React.js
 
 **[:arrow_up: back to top](#table-of-contents)**
-
-
-## Languages
-
-* [QML](https://doc.qt.io/qt-5/qmlapplications.html) You can use .js files to create native desktop and phone applications for all platforms with GPU acceleration and easy to code animations.
 
 
 ## Libraries


### PR DESCRIPTION
Background:

PR #134 from @ShalokShalom introduced a link to QML with the idea that one could make mobile and desktop applications with Elm. QML is very cool, and I really want this to be true, but unfortunately there seems to be no real-world example (I searched!)

There was a similar PR to Fable by same author who admits that it is currently only a hypothetical possibility:

https://github.com/fable-compiler/fable-compiler.github.io/issues/14#issuecomment-335104505

In the absence of a concrete example of using QML with Elm this link to QML is just going to confuse and distract people.

I propose removing this link.