### PR TITLE
Remove three dead/outdated links

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Inspired by the [awesome](#more-awesome) list thing. Feel free to <a href="https
 
 *Some good apps written in Elm.*
 
-* [Official list](http://elm-lang.org/examples) - Examples from _basic_ to _big-project_ in official website.
 * [Builtwithelm](http://builtwithelm.co/) - Web site built with elm with list of projects and apps built with Elm.
 * [Elm Joust](https://github.com/stefankreitmayer/elm-joust) — a two-player fighting game written in Elm.
 * [Vessel](https://github.com/slawrence/vessel) - A "tunnel" game written in Elm!
@@ -278,9 +277,7 @@ Inspired by the [awesome](#more-awesome) list thing. Feel free to <a href="https
 *Everything that you need to see.*
 
 * [Elm Search](http://klaftertief.github.io/elm-search/) - Search Elm documentation for operators, function signatures, etc.
-* [Try Elm](http://elm-lang.org/try) - Write and compile elm code online!
 * [404 Elm Street](https://github.com/zalando/elm-street-404) - A fun WebGL game built with Elm.
-* [Debug Elm](http://debug.elm-lang.org/try) - Debug elm code online.
 * [Haskell to Elm](https://github.com/eeue56/haskell-to-elm) - Collection of examples on places where Elm is different to Haskell, targeted at Elm beginners coming from Haskell backgrounds.
 * [runelm.io](https://runelm.io) - A place to share and run Elm code.
 * [Ellie](https://ellie-app.com/new) - The **El**m **Li**ve **E**ditor


### PR DESCRIPTION
I've deleted the formerly 404 link 'Official List' in my OP from Issue #159, and two somewhat related inaccessible links under the Misc heading. The first related link is another one to the 'Try Elm' site, which reports 'Poem 404, Page Not Found'. The second is to a Server not Found page: Debug Elm, related in the sense of no longer accessible, and possibly also mothballed on someone's server.

Although the 'Official List' link now points to an explanation page for why the Official List examples were mothballed, for the purposes of the Awesome Elm list it just provides another link, in the form of a large button at bottom of page, to the Official Guide, which's already included in the awesome listings farther down.

Also the second (formerly) dead link I mentioned a little farther into the thread in Issue #159 (the Official tutorial [evancz]), now seems to have been revived with new content that no longer says 'deprecated,' so I haven't touched that at all.

