### PR TITLE
Remove deprecated Elm VS Code plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,6 @@ Tools and libraries to test your Elm applications
 ### Visual Studio Code
 
 * [ElmLS](https://marketplace.visualstudio.com/items?itemName=Elmtooling.elm-ls-vscode) - Elm Language Server integration
-* [Elm Visual Studio Code Support](https://marketplace.visualstudio.com/items?itemName=sbrink.elm) - Syntax highlighting, Snippets, Function information, REPL, Reactor support (Webserver/Debugger) - Starting/Stopping
 * [Elmmet: Emmet for Elm (Visual Studio Code)](https://marketplace.visualstudio.com/items?itemName=necinc.elmmet) - Emmetio abbreviation expander into composition of Elm function with elm-format'er inside.
 * [HTML to Elm for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=Rubymaniac.vscode-html-to-elm) - VSCode plugin to convert HTML to Elm
 


### PR DESCRIPTION
Removed _Elm Visual Studio Code Support_ plugin from Visual Studio Code plugins list since it is deprecated.
![elm - Visual Studio Marketplace 2019-12-28 23-55-08](https://user-images.githubusercontent.com/3934846/71547994-8e42d300-29cd-11ea-936f-0714e08d524b.png)
