### PR TITLE
docs: Update dead link to Parcel

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ You can find hundreds of high quality packages at:
 
 * [elm-compiler](https://github.com/elm/compiler) - Compiler for the Elm programming language.
 * [elm-webpack-loader](https://github.com/elm-community/elm-webpack-loader) - Webpack loader for the Elm programming language.
-* [Parcel](https://parceljs.org/elm.html) - Bundle Elm using Parcel
+* [Parcel](https://parceljs.org/languages/elm/) - Bundle Elm using Parcel
 * [grunt-elm](https://github.com/rtfeldman/grunt-elm) - Grunt plugin that compiles Elm files to JavaScript.
 
 **[:top: back to top](#table-of-contents)**


### PR DESCRIPTION
I couldn't find URL changed commit in https://github.com/parcel-bundler/website, however it looks applied new URL.

<img width="775" alt="parcel-old" src="https://user-images.githubusercontent.com/1180335/176569487-23692b84-48bc-4bff-973f-7ee77d9aa1af.png">
<img width="667" alt="parcel-new" src="https://user-images.githubusercontent.com/1180335/176569484-b1b825fb-c016-44d6-acf9-3f9b68aa5ba8.png">
