### PR TITLE
@rtfeldman's talk on the spa example - added right next to the example links

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ You can find hundreds of high quality packages at:
 *Some good apps written in Elm.*
 
 * [Builtwithelm](http://builtwithelm.co/) - Web site built with elm with list of projects and apps built with Elm.
-* [Elm SPA Example](http://rtfeldman.github.io/elm-spa-example/) - Full stack Elm app w/ CRUD operations, Auth, routing, pagination and more. [Code](https://github.com/rtfeldman/elm-spa-example) / [Article](https://dev.to/rtfeldman/tour-of-an-open-source-elm-spa)
+* [Elm SPA Example](http://rtfeldman.github.io/elm-spa-example/) - Full stack Elm app w/ CRUD operations, Auth, routing, pagination and more. [Code](https://github.com/rtfeldman/elm-spa-example) / [Article](https://dev.to/rtfeldman/tour-of-an-open-source-elm-spa) / [Video](https://youtu.be/RN2_NchjrJQ)
 * [Elm Example App](https://github.com/sporto/elm-example-app) - A small SPA example in Elm to learn the basics
 * [TodoMVC](https://github.com/evancz/elm-todomvc) - Proper implementation of the TodoMVC app.
 * [TodoMVC with JSON API](https://github.com/andrewsuzuki/elm-todo-rest-api) - Bare-bones, modular, heavily-documented todo app with JSON API persistence.


### PR DESCRIPTION
Added @rtfeldman's talk explaining the [elm-spa-example](https://github.com/sporto/awesome-elm/pull/124).

Description of the talk by @rtfeldman himself:
> It's been almost 2 years since the widely referenced elm-spa-example's release in 2017, and a lot has changed! Where did all those new techniques come from? Why did the module structure change? What tips and tricks emerged over time? This talk explores the modernized Elm SPA in depth!